### PR TITLE
Minor fix on markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ index-based lookup. All indexing is zero based.
 ## Installation
 
 To install Bagz from source we recommend using
-[uv] (https://docs.astral.sh/uv/). The install will download required
+[uv](https://docs.astral.sh/uv/). The install will download required
 dependencies apart from curl (`libcurl-devel`) and OpenSSL (`openssl-devel`).
 These need to be installed in a location that cmake's `find_package` searches.
 


### PR DESCRIPTION
Before change:
<img width="839" alt="image" src="https://github.com/user-attachments/assets/94d986a8-24ce-4ab0-be5a-e24f6532ddc8" />


After change:
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/19df2905-c40d-4211-ac64-a342de304376" />
