### PR TITLE
Add macOS support: build wheels and document source install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,42 @@ index-based lookup. All indexing is zero based.
 ## Installation
 
 To install Bagz from source we recommend using [uv](https://docs.astral.sh/uv/).
-The install will download required dependencies apart from curl
-(`libcurl-devel`) and OpenSSL (`openssl-devel`). These need to be installed in a
-location that cmake's `find_package` searches.
+The build downloads its other dependencies automatically, but curl and OpenSSL
+must already be installed in a location that cmake's `find_package` searches.
+
+### Linux
+
+Install curl (`libcurl-devel`) and OpenSSL (`openssl-devel`) with your system
+package manager, then:
 
 ```sh
 uv pip install .
 ```
 
-On Linux you can install the latest version from PyPI.
+On Linux you can also install the latest version from PyPI:
 
 ```sh
 uv pip install bagz
 ```
+
+### macOS
+
+curl ships with the macOS SDK; install OpenSSL with [Homebrew](https://brew.sh):
+
+```sh
+brew install openssl@3
+```
+
+Homebrew keeps `openssl@3` keg-only, so point cmake at it explicitly to be sure
+`find_package` can locate it:
+
+```sh
+OPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" uv pip install .
+```
+
+(If `openssl@3` happens to be linked into your Homebrew prefix, a plain
+`uv pip install .` works too, but setting `OPENSSL_ROOT_DIR` is harmless and
+more portable.) There are no macOS wheels on PyPI yet, so install from source.
 
 ## Python API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ cmake.args = ["-Wno-dev"]
 # We need openssl3, which is only available in newer versions of the build
 # image.
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64:2024.12.16-1"
-build = "cp3*-manylinux_x86_64"
+build = "cp3*-manylinux_x86_64 cp3*-macosx_*"
 build-frontend = "build[uv]"
 build-verbosity = 1
 test-command = "pytest {package}/src"
@@ -66,4 +66,14 @@ yum install -y libcurl-devel openssl3-devel \
     && ln -s libcrypto.so.3 /usr/lib64/libcrypto.so
 '''
 
+# auditwheel is Linux-only; macOS uses the default delocate repair instead.
 repair-wheel-command = "auditwheel repair --strip -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.macos]
+# Build against Homebrew's openssl3 (CURL is provided by the system SDK). The
+# source builds its other dependencies (abseil, google-cloud-cpp, zstd, ...)
+# from source via CMake FetchContent, so no other system packages are needed.
+before-all = "brew install openssl@3"
+
+[tool.cibuildwheel.macos.environment]
+OPENSSL_ROOT_DIR = "$(brew --prefix openssl@3)"


### PR DESCRIPTION
This is an LLM-based attempt at adding macOS support, and it works! I would love to have macOS wheels on PyPI at some point, although this PR doesn't cover that.

The C++ extension is portable: its dependencies (abseil, pybind11, zstd, google-cloud-cpp and friends) are all fetched and built from source via CMake FetchContent, and the only system requirements are CURL (provided by the macOS SDK) and OpenSSL. Verified building and running on macOS arm64 against Homebrew's openssl@3.

cibuildwheel:
- Extend the `build` selector to also match `macosx_*`.
- Move `repair-wheel-command` (auditwheel) under `[tool.cibuildwheel.linux]`; auditwheel is Linux-only, so macOS falls back to the default delocate.
- Add a `[tool.cibuildwheel.macos]` section that installs openssl@3 and points `OPENSSL_ROOT_DIR` at its Homebrew prefix.

README:
- Split the install instructions into Linux and macOS subsections, covering the Homebrew OpenSSL setup and the `OPENSSL_ROOT_DIR` hint.