### PR TITLE
Add pickle serialization support for Reader and Options

### DIFF
--- a/src/bagz_reader.cc
+++ b/src/bagz_reader.cc
@@ -97,10 +97,11 @@ class InMemoryPReadFile : public PReadFile {
 }  // namespace
 
 struct BagzReader::State {
-  State(BagzReader::Options options,
+  State(std::string filespec, BagzReader::Options options,
         std::vector<internal::BagzShardReader> shards,
         std::vector<size_t> accumulated_count)
-      : options_(std::move(options)),
+      : filespec_(std::move(filespec)),
+        options_(std::move(options)),
         shards_(std::move(shards)),
         shard_indexing_(
             std::move(accumulated_count),
@@ -113,6 +114,9 @@ struct BagzReader::State {
       };
     }
   }
+
+  const BagzReader::Options& options() const { return options_; }
+  const std::string& filespec() const { return filespec_; }
 
   [[nodiscard]] size_t size() const { return shard_indexing_.size(); }
 
@@ -290,8 +294,6 @@ struct BagzReader::State {
     return static_cast<double>(num_bytes) / num_records;
   }
 
-  const BagzReader::Options& options() const { return options_; }
-
  private:
   static absl::Status DecompressInto(
       internal::ZstdDecompressor* decompressor, absl::string_view compressed,
@@ -342,6 +344,7 @@ struct BagzReader::State {
         /*cpu_bound=*/decompressor_factory_ != nullptr);
   }
 
+  std::string filespec_;
   Options options_;
   std::vector<internal::BagzShardReader> shards_;
   internal::ShardIndexing shard_indexing_;
@@ -512,7 +515,7 @@ absl::Status BagzReader::ReadIndicesWithAllocator(
 absl::StatusOr<BagzReader> BagzReader::OpenFiles(
     absl::Span<absl_nonnull std::unique_ptr<PReadFile>> record_files,
     absl::Span<absl_nonnull std::unique_ptr<PReadFile>> limits_files,
-    Options options) {
+    Options options, std::string filespec) {
   if (std::holds_alternative<CompressionAutoDetect>(options.compression)) {
     return absl::InvalidArgumentError(
         "Compression must not be kAutoDetect when calling "
@@ -588,8 +591,8 @@ absl::StatusOr<BagzReader> BagzReader::OpenFiles(
     }
   }
   return BagzReader(
-      std::make_shared<State>(std::move(options), std::move(shards),
-                              std::move(accumulated_count)),
+      std::make_shared<State>(std::move(filespec), std::move(options),
+                              std::move(shards), std::move(accumulated_count)),
       /*slice_start=*/0, /*slice_step=*/1, /*slice_length=*/total_count);
 }
 
@@ -622,7 +625,8 @@ absl::StatusOr<BagzReader> BagzReader::Open(absl::string_view filespec,
     }
     record_files = absl::MakeSpan(*all_files);
   }
-  return OpenFiles(record_files, limits_files, std::move(options));
+  return OpenFiles(record_files, limits_files, std::move(options),
+                   std::string(filespec));
 }
 
 absl::StatusOr<BagzReader::Handle> BagzReader::ReadHandle(size_t index) const {
@@ -687,6 +691,11 @@ absl::StatusOr<BagzReader> BagzReader::Slice(size_t start, int64_t step,
 
 const BagzReader::Options& BagzReader::options() const {
   return state_->options();
+}
+
+const std::string& BagzReader::filespec() const {
+  static const std::string* const empty_filespec = new std::string();
+  return state_ != nullptr ? state_->filespec() : *empty_filespec;
 }
 
 }  // namespace bagz

--- a/src/bagz_reader.h
+++ b/src/bagz_reader.h
@@ -89,7 +89,7 @@ class BagzReader {
   static absl::StatusOr<BagzReader> OpenFiles(
       absl::Span<absl_nonnull std::unique_ptr<PReadFile>> record_files,
       absl::Span<absl_nonnull std::unique_ptr<PReadFile>> limits_files,
-      Options options);
+      Options options, std::string filespec = "");
 
   // Opens a collection of Bagz-formatted files (shards).
   //
@@ -110,6 +110,18 @@ class BagzReader {
   // Returns view of the records in the bag.
   absl::StatusOr<BagzReader> Slice(size_t start, int64_t step,
                                    size_t length) const;
+
+  // Returns the filespec string used to open this reader.
+  const std::string& filespec() const;
+
+  // Returns the slice starting record index.
+  size_t slice_start() const { return slice_start_; }
+
+  // Returns the slice step.
+  int64_t slice_step() const { return slice_step_; }
+
+  // Returns the slice length.
+  size_t slice_length() const { return slice_length_; }
 
   // Returns the opening options.
   const Options& options() const;

--- a/src/python/bagz.pyi
+++ b/src/python/bagz.pyi
@@ -180,6 +180,14 @@ class Reader(Sequence[bytes]):
       options: options to use when reading, see `bagz.Reader.Options`.
     """
 
+  @property
+  def options(self) -> Reader.Options:
+    """Returns the options used to open the reader."""
+
+  @property
+  def file_spec(self) -> str:
+    """Returns the file_spec used to open the reader."""
+
   def count(self, value: bytes) -> int:
     """Returns the number of occurrences of the given value in the reader."""
 

--- a/src/python/bagz_options.cc
+++ b/src/python/bagz_options.cc
@@ -65,13 +65,18 @@ void RegisterBagzOptions(py::module& m) {
   py::class_<CompressionNone>(m, "CompressionNone",
                               "Override the default compression to be none.")
       .def(py::init([]() { return CompressionNone{}; }),
-           py::return_value_policy::move);
+           py::return_value_policy::move)
+      .def(py::pickle([](const CompressionNone&) { return py::make_tuple(); },
+                      [](py::tuple) { return CompressionNone{}; }));
 
   py::class_<CompressionAutoDetect>(
       m, "CompressionAutoDetect",
       "Use the default compression for the filename extension.")
       .def(py::init([]() { return CompressionAutoDetect{}; }),
-           py::return_value_policy::move);
+           py::return_value_policy::move)
+      .def(py::pickle(
+          [](const CompressionAutoDetect&) { return py::make_tuple(); },
+          [](py::tuple) { return CompressionAutoDetect{}; }));
 
   py::class_<CompressionZstd>(m, "CompressionZstd", "Use Zstd compression.")
       .def(py::init([](int level, absl::string_view dictionary) {
@@ -81,7 +86,18 @@ void RegisterBagzOptions(py::module& m) {
            py::arg("level") = 0, py::arg("dictionary") = "",
            py::return_value_policy::move, py::doc(kCompressionZtdInitDoc + 1))
       .def_readwrite("level", &CompressionZstd::level)
-      .def_readwrite("dictionary", &CompressionZstd::dictionary);
+      .def_readwrite("dictionary", &CompressionZstd::dictionary)
+      .def(py::pickle(
+          [](const CompressionZstd& c) {
+            return py::make_tuple(c.level, c.dictionary);
+          },
+          [](py::tuple t) {
+            if (t.size() != 2) {
+              throw py::type_error("Invalid state for CompressionZstd!");
+            }
+            return CompressionZstd{.dictionary = t[1].cast<std::string>(),
+                                   .level = t[0].cast<int>()};
+          }));
 
   py::enum_<ShardingLayout>(m, "ShardingLayout", kShardingLayoutEnumDoc + 1)
       .value("CONCATENATED", ShardingLayout::kConcatenated,

--- a/src/python/bagz_reader.cc
+++ b/src/python/bagz_reader.cc
@@ -522,11 +522,66 @@ void RegisterBagzReader(py::module& m) {
       .def_readwrite("limits_placement", &BagzReader::Options::limits_placement)
       .def_readwrite("compression", &BagzReader::Options::compression)
       .def_readwrite("limits_storage", &BagzReader::Options::limits_storage)
-      .def_readwrite("max_parallelism", &BagzReader::Options::max_parallelism);
+      .def_readwrite("max_parallelism", &BagzReader::Options::max_parallelism)
+      .def(py::pickle(
+          [](const BagzReader::Options& options) {
+            return py::make_tuple(
+                options.sharding_layout, options.limits_placement,
+                options.compression, options.limits_storage,
+                options.max_parallelism, options.read_ahead_bytes);
+          },
+          [](py::tuple t) {
+            if (t.size() != 6) {
+              throw py::type_error("Invalid state for BagzReader.Options!");
+            }
+            return BagzReader::Options{
+                .sharding_layout = t[0].cast<ShardingLayout>(),
+                .limits_placement = t[1].cast<LimitsPlacement>(),
+                .compression = t[2].cast<Compression>(),
+                .limits_storage = t[3].cast<LimitsStorage>(),
+                .max_parallelism = t[4].cast<int>(),
+                .read_ahead_bytes = t[5].cast<std::optional<size_t>>(),
+            };
+          }));
 
   reader
       .def(py::init(&Init), py::arg("file_spec"),
            py::arg("options") = BagzReader::Options{}, py::doc(kInitDoc + 1))
+      .def_property_readonly("options", &BagzReader::options)
+      .def_property_readonly("file_spec", &BagzReader::filespec)
+      .def(py::pickle(
+          [](const BagzReader& reader) {
+            if (reader.filespec().empty()) {
+              throw py::type_error(
+                  "Cannot pickle BagzReader opened without a file_spec path.");
+            }
+            return py::make_tuple(reader.filespec(), reader.options(),
+                                  reader.slice_start(), reader.slice_step(),
+                                  reader.slice_length());
+          },
+          [](py::tuple t) {
+            if (t.size() != 5) {
+              throw py::type_error("Invalid state for BagzReader!");
+            }
+            std::string filespec = t[0].cast<std::string>();
+            BagzReader::Options options = t[1].cast<BagzReader::Options>();
+            size_t slice_start = t[2].cast<size_t>();
+            int64_t slice_step = t[3].cast<int64_t>();
+            size_t slice_length = t[4].cast<size_t>();
+
+            absl::StatusOr<BagzReader> reader =
+                BagzReader::Open(filespec, std::move(options));
+            ThrowNonOkStatusAsException(reader.status());
+
+            if (slice_start == 0 && slice_step == 1 &&
+                slice_length == reader->size()) {
+              return *std::move(reader);
+            }
+            absl::StatusOr<BagzReader> slice =
+                reader->Slice(slice_start, slice_step, slice_length);
+            ThrowNonOkStatusAsException(slice.status());
+            return *std::move(slice);
+          }))
       .def("__len__", &BagzReader::size)
       .def("__getitem__", &GetItem, py::arg("index"), py::doc(kGetItemDoc + 1))
       .def("__getitem__", &GetSlice, py::arg("slice"), py::doc(kGetItemDoc + 1))

--- a/src/python/bagz_test.py
+++ b/src/python/bagz_test.py
@@ -19,7 +19,9 @@ from typing import TypeAlias
 
 from absl.testing import absltest
 from absl.testing import parameterized
+import multiprocessing as mp
 import numpy as np
+import pickle
 
 import bagz
 
@@ -427,6 +429,76 @@ class BagTest(parameterized.TestCase):
       for _ in range(4):
         next(item_iter)
       del item_iter
+
+  def test_reader_pickle(self) -> None:
+    file = pathlib.Path(self.create_tempdir()) / 'data.bagz'
+    records = list(_generate_records(_NUM_RECORDS))
+    with bagz.Writer(file) as writer:
+      for rec in records:
+        writer.write(rec)
+
+    reader = bagz.Reader(file)
+    unpickled_reader = pickle.loads(pickle.dumps(reader))
+
+    self.assertEqual(len(unpickled_reader), len(reader))
+    self.assertEqual(list(unpickled_reader), records)
+    self.assertEqual(unpickled_reader[5], records[5])
+
+  def test_sliced_reader_pickle(self) -> None:
+    file = pathlib.Path(self.create_tempdir()) / 'data.bagz'
+    records = list(_generate_records(_NUM_RECORDS))
+    with bagz.Writer(file) as writer:
+      for rec in records:
+        writer.write(rec)
+
+    reader = bagz.Reader(file)
+    sliced_reader = reader[3:15:2]
+
+    unpickled_slice = pickle.loads(pickle.dumps(sliced_reader))
+    self.assertEqual(list(unpickled_slice), list(sliced_reader))
+    self.assertEqual(unpickled_slice[0], sliced_reader[0])
+
+  def test_reader_options_pickle(self) -> None:
+    file = pathlib.Path(self.create_tempdir()) / 'data.bagz'
+    records = list(_generate_records(_NUM_RECORDS))
+    with bagz.Writer(file) as writer:
+      for rec in records:
+        writer.write(rec)
+
+    options = bagz.Reader.Options(
+        max_parallelism=8,
+        limits_storage=bagz.LimitsStorage.IN_MEMORY,
+        compression=bagz.CompressionZstd(level=3),
+    )
+    reader = bagz.Reader(file, options=options)
+
+    unpickled_reader = pickle.loads(pickle.dumps(reader))
+    self.assertEqual(unpickled_reader.options.max_parallelism, 8)
+    self.assertEqual(
+        unpickled_reader.options.limits_storage, bagz.LimitsStorage.IN_MEMORY
+    )
+    self.assertEqual(unpickled_reader[0], records[0])
+
+  def test_multiprocessing_pool(self) -> None:
+    file = pathlib.Path(self.create_tempdir()) / 'data.bagz'
+    records = list(_generate_records(_NUM_RECORDS))
+    with bagz.Writer(file) as writer:
+      for rec in records:
+        writer.write(rec)
+
+    reader = bagz.Reader(file)
+
+    ctx = mp.get_context('fork') if 'fork' in mp.get_all_start_methods() else mp.get_context()
+    with ctx.Pool(processes=2) as pool:
+      results = pool.starmap(
+          _read_worker_helper, [(reader, i) for i in range(len(reader))]
+      )
+
+    self.assertEqual(results, records)
+
+
+def _read_worker_helper(reader: bagz.Reader, idx: int) -> bytes:
+  return reader[idx]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
This PR adds Python `pickle` serialization (`pickle.dumps` / `pickle.loads`) support for `bagz.Reader`, `bagz.Reader.Options`, and `Compression` classes via pybind11's `py::pickle` protocol.

## Motivation & Context
When using `bagz.Reader` in multi-worker Python data loading pipelines (e.g. PyGrain multi-worker DataLoader, PyTorch `DataLoader(num_workers > 0)`, `multiprocessing.Pool`), reader instances need to be pickled across process boundaries. Previously, `bagz.Reader` was an unpicklable C++ class, raising `TypeError: cannot pickle 'bagz.lib.bagz.Reader' object`.

## Changes
1. **Expose Reader Metadata**:
   - Stored `filespec_` in `BagzReader::State` and exposed `filespec()`, `slice_start()`, `slice_step()`, and `slice_length()` getters in `BagzReader`.
2. **Options & Compression Pickle**:
   - Registered `py::pickle` for `CompressionNone`, `CompressionAutoDetect`, and `CompressionZstd` in `src/python/bagz_options.cc`.
   - Registered `py::pickle` for `BagzReader::Options` in `src/python/bagz_reader.cc`.
3. **Reader Pickle & Reconstruction**:
   - Registered `py::pickle` for `bagz.Reader`: serializes `(filespec, options, slice_start, slice_step, slice_length)` on `__getstate__` and lazily reopens the reader / reconstructed slice view on `__setstate__`.
4. **Typing**:
   - Added `Reader.options` and `Reader.file_spec` properties in `src/python/bagz.pyi`.
5. **Tests**:
   - Added unit tests in `src/python/bagz_test.py` covering:
     - Basic `Reader` pickling & record integrity verification
     - Sliced view `reader[3:15:2]` pickling & alignment
     - Custom `Reader.Options` pickling (parallelism, limits storage, compression)
     - Multi-worker execution with `multiprocessing.Pool`

## Verification
- Passed all unit tests in `src/python/bagz_test.py`.
- Passed full test suite in `//third_party/bagz/open_source/...` (27/27 tests passed).
